### PR TITLE
16A VR1 modules

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -46,6 +46,8 @@ dependencies:
   - matplotlib==3.10.5
   - sympy==1.14.0
   - pandas==2.3.1
+  - pyaudio==0.2.14
+  - sounddevice==0.5.3
   # For EECS127/227a
   # See https://github.com/berkeley-dsep-infra/datahub/issues/1631
   - cvxpy==1.7.1

--- a/environment.yml
+++ b/environment.yml
@@ -47,7 +47,7 @@ dependencies:
   - sympy==1.14.0
   - pandas==2.3.1
   - pyaudio==0.2.14
-  - sounddevice==0.5.3
+  - python-sounddevice>0.5
   # For EECS127/227a
   # See https://github.com/berkeley-dsep-infra/datahub/issues/1631
   - cvxpy==1.7.1


### PR DESCRIPTION
The modules pyaudio and python-sounddevice need to be added for EECS 16A's VR1 and VR2 lab.